### PR TITLE
2.2.2

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,12 @@ Data processing methodology can be determined by date `(dd/mm/yyyy)` or by exami
 
 ### Version history
 
+#### 2.2.2
+  -   Data analysed with workflow 2.2.2 will contain the following information in the `info.txt` file:
+      -   `Dataset methodology=bpaotu_x.x.x__analysis_2.2.2__AM_db_vx.x_xxxxxxxxxxxx.db__AM_data_submit_xxxxxxxxxxxx.tar.gz`
+   **Change summary**
+   - Fixed typographical error in platewise zotu calling where minimum size was defined as 8, corrections reflect the minimum size of 4.
+
 #### 2.2.1
 
 **Transition from workflows documented in a single Microsoft word file `(.docx)` to individual markdown `(.md)` files for each analysis**

--- a/docs/fungal_ITS_amplicon_workflow.md
+++ b/docs/fungal_ITS_amplicon_workflow.md
@@ -153,9 +153,9 @@ The first step removes sequences that have ambiguous bases, or have more than 12
 
     usearch -sortbysize plateID_all_ITSn.good_uniques.fasta -fastaout plateID_all_ITSn.good_sorted_uniques.fasta -sizeout
 
-**ZOTUs are called by *UNOISE3*, from sequences that have => 8 representatives:**
+**ZOTUs are called by *UNOISE3*, from sequences that have => 4 representatives:**
 
-    usearch -unoise3 plateID_all_ITSn.good_sorted_uniques.fasta -zotus plateID_all_ITSn.good_sorted_uniques_zotus.fasta -ampout plateID_all_ITSn.good_sorted_uniques_ampout.fasta -tabbedout plateID_all_ITSn.good_sorted_uniques_unoise3.txt -minsize 8
+    usearch -unoise3 plateID_all_ITSn.good_sorted_uniques.fasta -zotus plateID_all_ITSn.good_sorted_uniques_zotus.fasta -ampout plateID_all_ITSn.good_sorted_uniques_ampout.fasta -tabbedout plateID_all_ITSn.good_sorted_uniques_unoise3.txt -minsize 4
 
 Combine the ZOTUs obtained from sample-wise and plate-wise analysis with a defined set of "prior" sequences into a single fasta file. The resulting file name is standardised to the format:
 


### PR DESCRIPTION
Fixed typo in ITS platewise zotu calling where minsize was defined as 8 instead of 4